### PR TITLE
Hide logos on mobile

### DIFF
--- a/src/components/AppWrapper/index.js
+++ b/src/components/AppWrapper/index.js
@@ -8,6 +8,7 @@ import Nav from '../Nav';
 import Legend from '../Legend';
 import Loading from '../Loading';
 import Overlay from '../Overlay';
+import Credits from '../Credits';
 
 import logoCitylab from '!file-loader!../../assets/citylab-logo.svg';
 import logoTSB from '!file-loader!../../assets/tsb-logo-coloured.svg';
@@ -20,33 +21,16 @@ const AppWrapperDiv = styled.div`
 `;
 
 const CreditsContainer = styled.div`
-  width: 150px;
-  height: auto;
   position: absolute;
-  flex-direction: column;
-  display: flex;
-  justify-content: end;
   top: 12px;
   right: 12px;
 
-  span {
-    margin-bottom: 5px;
-    width: fit-content;
-    font-size: ${p => p.theme.fontSizeL}
+  @media screen and (max-width: ${p => p.theme.screens.tablet}) {
+    display: none;
   }
 
-  a.tsb {
-    width: fit-content;
-    img {
-      width: 110px;
-    }
-  }
-
-  a.citylab {
-    img {
-      width: 150px;
-      margin: 10px 0 5px 0;
-    }
+  @media screen and (min-width: ${p => p.theme.screens.tablet}) {
+    display: block;
   }
 `;
 
@@ -60,13 +44,7 @@ const AppWrapper = p => {
       {overlay && data && (<Overlay/>)}
       <Nav/>
       <CreditsContainer>
-        <span>Ein Projekt des</span>
-        <a className="citylab" href="https://citylab-berlin.org" target="_blank">
-          <img src={logoCitylab} />
-        </a>
-        <a className="tsb" href="https://technologiestiftung-berlin.de" target="_blank">
-          <img src={logoTSB} />
-        </a>
+        <Credits/>
       </CreditsContainer>
       <Legend />
     </AppWrapperDiv>

--- a/src/components/Credits/index.js
+++ b/src/components/Credits/index.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import logoCitylab from '!file-loader!../../assets/citylab-logo.svg';
+import logoTSB from '!file-loader!../../assets/tsb-logo-coloured.svg';
+
+const StyledCreditsContainer = styled.div`
+  width: 150px;
+  height: auto;
+  flex-direction: column;
+  display: flex;
+  justify-content: end;
+
+  span {
+    margin-bottom: 5px;
+    width: fit-content;
+    font-size: ${p => p.theme.fontSizeL}
+  }
+
+  a.tsb {
+    width: fit-content;
+    img {
+      width: 110px;
+    }
+  }
+
+  a.citylab {
+    img {
+      width: 150px;
+      margin: 10px 0 5px 0;
+    }
+  }
+`;
+
+const Credits = p => {
+  return (
+    <StyledCreditsContainer>
+      <span>Ein Projekt des</span>
+      <a className="citylab" href="https://citylab-berlin.org" target="_blank">
+        <img src={logoCitylab} />
+      </a>
+      <a className="tsb" href="https://technologiestiftung-berlin.de" target="_blank">
+        <img src={logoTSB} />
+      </a>
+    </StyledCreditsContainer>
+  )
+}
+
+export default Credits;

--- a/src/components/Overlay/OverlayBottom/index.js
+++ b/src/components/Overlay/OverlayBottom/index.js
@@ -4,29 +4,13 @@ import styled from 'styled-components';
 import OverlayTiles from '../OverlayTiles/';
 import OverlayTitle from '../OverlayTitle/';
 import content from "../../../assets/content";
-import Credits from '../../Credits';
 
 const StyledBottom = styled.div`
   opacity: 1;
   height: auto;
   width: 100%;
-`;
-
-const CollaborateContainer = styled.div`
   background-color: #F7F7F7;
   padding: 40px 0;
-`;
-
-const CreditsContainer = styled.div`
-  margin: 40px;
-
-  @media screen and (max-width: ${p => p.theme.screens.tablet}) {
-    position: relative;
-  }
-
-  @media screen and (min-width: ${p => p.theme.screens.tablet}) {
-    display: none;
-  }
 `;
 
 const OverlayBottom = p => {
@@ -34,17 +18,10 @@ const OverlayBottom = p => {
   const { collaborate } = content;
 
   return (
-    <>
-      <StyledBottom>
-        <CollaborateContainer>
-          <OverlayTitle content={collaborate.title}/>
-          <OverlayTiles content={collaborate.tiles}/>
-        </CollaborateContainer>
-        <CreditsContainer>
-          <Credits/>
-        </CreditsContainer>
-      </StyledBottom>
-    </>
+    <StyledBottom>
+      <OverlayTitle content={collaborate.title}/>
+      <OverlayTiles content={collaborate.tiles}/>
+    </StyledBottom>
   )
 }
 

--- a/src/components/Overlay/OverlayBottom/index.js
+++ b/src/components/Overlay/OverlayBottom/index.js
@@ -4,13 +4,29 @@ import styled from 'styled-components';
 import OverlayTiles from '../OverlayTiles/';
 import OverlayTitle from '../OverlayTitle/';
 import content from "../../../assets/content";
+import Credits from '../../Credits';
 
 const StyledBottom = styled.div`
   opacity: 1;
-  background-color: #F7F7F7;
   height: auto;
   width: 100%;
+`;
+
+const CollaborateContainer = styled.div`
+  background-color: #F7F7F7;
   padding: 40px 0;
+`;
+
+const CreditsContainer = styled.div`
+  margin: 40px;
+
+  @media screen and (max-width: ${p => p.theme.screens.tablet}) {
+    position: relative;
+  }
+
+  @media screen and (min-width: ${p => p.theme.screens.tablet}) {
+    display: none;
+  }
 `;
 
 const OverlayBottom = p => {
@@ -18,10 +34,17 @@ const OverlayBottom = p => {
   const { collaborate } = content;
 
   return (
-    <StyledBottom>
-      <OverlayTitle content={collaborate.title}/>
-      <OverlayTiles content={collaborate.tiles}/>
-    </StyledBottom>
+    <>
+      <StyledBottom>
+        <CollaborateContainer>
+          <OverlayTitle content={collaborate.title}/>
+          <OverlayTiles content={collaborate.tiles}/>
+        </CollaborateContainer>
+        <CreditsContainer>
+          <Credits/>
+        </CreditsContainer>
+      </StyledBottom>
+    </>
   )
 }
 

--- a/src/components/Sidebar/SidebarAbout/index.js
+++ b/src/components/Sidebar/SidebarAbout/index.js
@@ -5,6 +5,7 @@ import SidebarTitle from '../SidebarTitle/';
 import CardHeadline from '../../Card/CardHeadline/';
 import CardDescription from '../../Card/CardDescription/';
 import CardDescriptionTitle from '../../Card/CardDescriptionTitle/';
+import Credits from '../../Credits';
 
 import content from "../../../assets/content";
 
@@ -30,7 +31,19 @@ const PanelWrapper = styled.div`
   padding-bottom: 10px;
   animation: sweep .125s ease-in-out;
   margin-bottom: 10px;
-`
+`;
+
+const CreditsContainer = styled.div`
+  margin-bottom: 10px;
+
+  @media screen and (max-width: ${p => p.theme.screens.tablet}) {
+    position: relative;
+  }
+
+  @media screen and (min-width: ${p => p.theme.screens.tablet}) {
+    display: none;
+  }
+`;
 
 const SidebarAbout = p => {
   const { sidebar } = content;
@@ -45,6 +58,9 @@ const SidebarAbout = p => {
           <StyledCardDescription dangerouslySetInnerHTML={createMarkup(item.description)}></StyledCardDescription>
         </PanelWrapper>
       ))}
+      <CreditsContainer>
+        <Credits/>
+      </CreditsContainer>
     </>
   )
 }


### PR DESCRIPTION
This PR creates a _Credits_ component for the the logos and displays it according to the screen width in either:
- the top right corner of the map
- or inside the infobox