### PR TITLE
fix: typos in overlay and profile

### DIFF
--- a/src/assets/content.js
+++ b/src/assets/content.js
@@ -1,7 +1,7 @@
 const content = {
 	intro: {
 		title: '<b>Gieß den <span>Kiez</span></b>',
-		subline: 'Die Berliner Stadtbäume leiden unter Trockenheit <br class="large" /> und Du kannst Ihnen helfen!',
+		subline: 'Die Berliner Stadtbäume leiden unter Trockenheit <br class="large" /> und Du kannst ihnen helfen!',
 		description: ['Auf dieser Plattform kannst Du Dich über Bäume in deiner Nachbarschaft und ihren Wasserbedarf informieren. Du kannst einzelne Bäume abonnieren und markieren, wenn Du sie gegossen hast.', 'Oder informiere Dich ich über das richtige Gießen von Stadtbäumen. Wenn Du die Seite regelmäßig nutzen möchtest, solltest Du ein Konto erstellen. Die Karte kannst Du aber auch ohne Konto erkunden.']
 	},
 	sidebar: {

--- a/src/components/Sidebar/SidebarProfile/index.js
+++ b/src/components/Sidebar/SidebarProfile/index.js
@@ -201,7 +201,7 @@ const SidebarProfile = p => {
                       dir generierten Wässerungsdaten einem anonymen Benutzer
                       zugeordnet. Dein Benutzer bei unserem
                       Authentifizierungsdienst Auth0.com wird sofort und
-                      unwiederruflich gelöscht.
+                      unwiderruflich gelöscht.
                     </CardParagraph>
                     <ButtonRound
                       width="-webkit-fill-available"


### PR DESCRIPTION
This PR fixes two small typos:
- in overlay: "Ihnen" -> "ihnen"
- in profile: "unwiederruflich" -> "unwiderruflich"