### PR TITLE
fix: include correct data provenance section

### DIFF
--- a/src/assets/content.js
+++ b/src/assets/content.js
@@ -16,11 +16,6 @@ const content = {
           'Die Folgen des Klimawandels, insbesondere die trockenen und heißen Sommer, belasten das Berliner Ökosystem. Unsere Straßenbäume vertrocknen und tragen langfristige Schäden davon: in den letzten Jahren mussten immer mehr Bäume gefällt werden und ihre Lebensdauer sinkt. Inzwischen wird regelmäßig sogar die Bevölkerung zur Unterstützung aufgerufen, allerdings weitgehend unkoordiniert. Dies möchten wir mit diesem Projekt ändern und die koordinierte Bürger*innenbeteiligung und bei der Bewässerung städtischen Grüns ermöglichen.',
       },
       {
-        title: 'Plattform und Daten',
-        description:
-          "Gieß den Kiez ist eine interaktive Karte, auf der sich NutzerInnen über den Wasserbedarf der Berliner Bäume informieren können. Die Karte zeigt alle <a target='_blank' href='https://fbinter.stadt-berlin.de/fb/berlin/service_intern.jsp?id=s_wfs_baumbestand@senstadt&type=WFS'>Straßen-</a> und <a href='https://fbinter.stadt-berlin.de/fb/berlin/service_intern.jsp?id=s_wfs_baumbestand_an@senstadt&type=WFS' target='_blank'>Anlagenbäume</a> (Stand: 14.06.2019) des Geoportals von Berlin. Es wird abgebildet wie viel Niederschlag in den letzten 30 Tagen bei jedem Baum gefallen ist und ob diese in der Zeit bereits gegossen wurden. Nutzer*innen können einzelne Bäume abonnieren und markieren, wenn diese gegossen wurden. Die Baumdaten stammen vom Berliner Geoportal FIS Broker. Die Niederschlagsdaten werden täglich vom <a href='https://dwd.de' target='blank'>Deutschen Wetterdienst</a> bereitgestellt. Die Wasserpumpen werden von <a href='https://www.openstreetmap.de/' target='_blank'>OpenStreetMap</a> bereitgestellt.",
-      },
-      {
         title: 'Die richtige Bewässerung',
         description:
           'Je nach Alter, Standort und Baumart benötigen Bäume unterschiedlich viel Wasser. Jungbäume (0-15 Jahre), benötigen mehr Wasser als mittelalte Bäume (15-40 Jahre), und Altbäume (ab 40 Jahre) sind komplette Selbstversorger. Da frisch gepflanzte Bäume bis zum Alter von drei Jahren von der Berliner Verwaltung mit Wasser versorgt werden, benötigen besonders die Bäume zwischen vier und 15 Jahren unsere Aufmerksamkeit, beziehungsweise unser Wasser. Dies haben wir mit den Kennzeichungen des geringen, mittleren oder hohen Wasserbedarfs hervorgehoben. <br /> <br /> Angelehnt an das Berliner <a target="blank" href="https://www.berlin.de/senuvk/umwelt/stadtgruen/pflege_unterhaltung/de/hgp/index.shtml">Handbuch Gute Pflege</a> empfehlen wir euch, lieber seltener zu wässern, dafür mit einer größeren Menge an Wasser. Das Handbuch empfiehlt für frisch gepflanzte Bäume bis zu 200l pro Gießung. So sorgt ihr dafür, dass die Bodenfeuchte auch in der Tiefe erhöht wird. Im Endeffekt schaden aber auch kleinere Mengen gerade im Hochsommer nicht. Wichtig ist es, den ausgetrockneten Boden vor dem Gießen aufzulockern, sodass das Wasser in den Boden eindringen kann und nicht wegläuft oder sich falsch anstaut.',
@@ -39,6 +34,11 @@ const content = {
         title: 'Über uns',
         description:
           '“Gieß den Kiez” ist ein Projekt des <a target="blank" href="https://www.citylab-berlin.org/">CityLAB Berlin</a>. Das CityLAB ist ein öffentliches Innovationslabor für die Stadt der Zukunft im ehemaligen Flughafen Berlin-Tempelhof. Gemeinsam mit einem großen Netzwerk aus Verwaltung, Zivilgesellschaft, Wissenschaft und Start-ups arbeiten wir an neuen Ideen für ein lebenswertes Berlin. Das CityLAB ist ein offener Ort zum Mitmachen! Wenn ihr mehr wissen wollt, schaut euch auf unserer Webseite um oder kommt einfach mal vorbei! <br /> <br /> Das CityLAB ist ein Projekt der Technologiestiftung Berlin und wird finanziert durch die Berliner Senatskanzlei. <br /> <br /> <a target="blank" href="https://www.technologiestiftung-berlin.de/de/impressum/">Impressum</a> <br/> <a target="blank" href="https://www.technologiestiftung-berlin.de/de/datenschutz/">Datenschutz</a>',
+      },
+      {
+        title: 'Datenquellen',
+        description:
+          '<ul><li><a target="blank" href="https://fbinter.stadt-berlin.de/fb/berlin/service_intern.jsp?id=s_wfs_baumbestand@senstadt&type=WFS">Geoportal Berlin / Straßenbäume</a></li><li><a target="blank" href="https://fbinter.stadt-berlin.de/fb/berlin/service_intern.jsp?id=s_wfs_baumbestand_an@senstadt&type=WFS">Geoportal Berlin / Anlagenbäume</a></li><li><a target="blank" href="https://www.dwd.de/">Deutscher Wetterdienst</a></li><li>Wasserpumpen von <a target="blank" href="https://www.openstreetmap.de/">OpenStreetMap</a></li></ul>',
       },
     ],
     watering: [


### PR DESCRIPTION
This PR 
- adds the correct note for data provenance at the bottom of the sidebar
- removes the "Plattform und Daten" section in the sidebar

Fixes #94 
Also fixes #42 