### PR TITLE
fix(overlay): use single column on small screens

### DIFF
--- a/src/components/Overlay/OverlayDescription/index.js
+++ b/src/components/Overlay/OverlayDescription/index.js
@@ -7,8 +7,9 @@ const Wrapper = styled.div`
   margin: 0 40px;
   grid-template-columns: repeat(auto-fill, minmax(20em, 1fr));
 
-  @media screen and (max-width: 768px) {
+  @media screen and (max-width: ${p => p.theme.screens.tablet}) {
     gap: 0rem;
+    grid-template-columns: 1fr;
   }
 `;
 

--- a/src/components/Overlay/OverlayTiles/index.js
+++ b/src/components/Overlay/OverlayTiles/index.js
@@ -8,6 +8,10 @@ const Wrapper = styled.div`
   gap: 1rem;
   margin: 0 40px;
   grid-template-columns: repeat(auto-fill, minmax(20em, 1fr));
+
+  @media screen and (max-width: ${p => p.theme.screens.tablet}) {
+    grid-template-columns: 1fr;
+  }
 `;
 
 // const StyledParargraph = styled.p`


### PR DESCRIPTION
This PR fixes #151 by using a `1fr` column on small screens instead of a column spanning `minmax(20em, 1fr)`.

@sebastian-meier can you please review if this fixes the issue?