### PR TITLE
fix(viewport): move to correct location

### DIFF
--- a/src/components/Card/CardAccordion/TreesAdopted.js
+++ b/src/components/Card/CardAccordion/TreesAdopted.js
@@ -52,7 +52,7 @@ const TreesAdopted = p => {
 
   const handleClick = async info => {
     Store.setState({ selectedTree: info });
-    const coordinates = [parseFloat(info.lng), parseFloat(info.lat)];
+    const coordinates = [parseFloat(info.lat), parseFloat(info.lng)];
     setViewport(coordinates);
   };
 


### PR DESCRIPTION
This PR fixes #162 by exchanging latitude and longitude when selecting an adopted tree from the user's sidebar.

**But**: the `setViewport` function actually expects longitude on index 0 and longitude on index 1. Is there something wrong with the naming of the properties?