### PR TITLE
Fix typos in non-verified-mail.tsx

### DIFF
--- a/src/components/Card/non-verified-mail.tsx
+++ b/src/components/Card/non-verified-mail.tsx
@@ -5,9 +5,9 @@ export const NonVerfiedMailCardParagraph = () => {
   return (
     <CardParagraph>
       Du hast deine E-Mail Adresse noch nicht verifiziert. Bitte wirf einen
-      Blick in dein Postfach ob du eine Mail von
+      Blick in dein Postfach, ob du eine E-Mail von
       &ldquo;no-reply@auth0user.net&ldquo; erhalten hast und klicke auf den
-      enthaltenen Link um dies zu tun. Vielleicht sind wir auch im Spam Ordern
+      enthaltenen Link, um dies zu tun. Vielleicht sind wir auch im Spam-Ordner
       gelandet?
     </CardParagraph>
   );


### PR DESCRIPTION
I created an account and saw a bad spelling on the page while waiting for the verify mail. This made me think of directly creating this pull request with proposing the required fixes.

- inserted commas
- corrected Spam-Ordner