### PR TITLE
Change rainfall chart scaling from 0-300 to 0-100l/m² per day

### DIFF
--- a/src/components/Linechart/index.tsx
+++ b/src/components/Linechart/index.tsx
@@ -73,7 +73,7 @@ const Linechart = p => {
       setScaleTime(() => scaleTime);
 
       const scaleRain = scaleLinear()
-        .domain([0, 300]) // @TODO: check the hours of the day
+        .domain([0, 100]) // @TODO: check the hours of the day
         .range([height - margin.top - margin.bottom, 0]);
       setScaleRain(() => scaleRain);
 


### PR DESCRIPTION
With scaling 0-300 l/m², the usual rainfall is barely visible in the "rainfall per day" chart. 0-100 l/m² should be more adequate. Average rainfall in Berlin is below 100l/m² per month, so even most heavy rainfall days should be covered (except e.g. 2017 floods with up to 200 l/m², but those are rare cases) while making average amounts more visible. Very light rain is still not visible with 0-100 l/m² scaling, but it's also not that relevant for trees.